### PR TITLE
Fix FreeBSD's frr start

### DIFF
--- a/frr/config.sls
+++ b/frr/config.sls
@@ -50,8 +50,8 @@ frr_service_{{ service }}_activation:
 
 
 frr_service_config_{{ service }}:
-{%-     if config %}
-{%-   if not map.use_integrated_mode %}
+{%-   if config %}
+{%-     if not map.use_integrated_mode %}
   file.managed:
     - source: salt://frr/files/frr.conf.jinja
     - template: jinja
@@ -126,14 +126,6 @@ frr_reload:
     - onchanges:
       - service: frr_service
 
-{%-   if map.manage_sysrc %}
-frr_vtysh_boot:
-  sysrc.managed:
-    - value: "{{ "YES" if map.use_integrated_mode else "NO" }}"
-    - require_in:
-       - service: frr_service
-{%-   endif %}
-
 {%- else %}{# not map.use_integrated_mode #}
 
 frr_service_config:
@@ -142,6 +134,13 @@ frr_service_config:
 
 {%- endif %}
 
+{%- if map.manage_sysrc %}
+frr_vtysh_boot:
+  sysrc.managed:
+    - value: "{{ "YES" if (map.use_integrated_mode and map.use_vtysh) else "NO" }}"
+    - require_in:
+       - service: frr_service
+{%- endif %}
 
 {%- if map.one_service_to_start_them_all %}
 

--- a/frr/osfamilymap.yaml
+++ b/frr/osfamilymap.yaml
@@ -4,4 +4,4 @@ FreeBSD:
   use_daemons_file: False
   manage_sysrc: True
   use_integrated_mode: False
-  use_vtysh: True
+  use_vtysh: False


### PR DESCRIPTION
Without this patch `service frr start` results in 

```
# service frr start                                                                               
Checking intergrated config...                                                                           
Checking vtysh.conf                                                                                       
% Can't open configuration file /usr/local/etc/frr/frr.conf due to 'No such file or directory'.          
FAILED
```

Which means only the formula would start the services, because (I suppose) it uses  `service frr onestart` internally.
At boot FRR services would be stopped!

Now, the trick is to disable `frr_vtysh_boot` in `/etc/rc.conf`.

Tested on

- FreeBSD 11.2
- Debian 9.8