### PR TITLE
Added support for service flags

### DIFF
--- a/frr/config.sls
+++ b/frr/config.sls
@@ -1,20 +1,9 @@
 {%- from "frr/map.jinja" import map with context %}
+{%- from "frr/macros.jinja" import service_dependencies %}
 
 {%- set services_defaults = {
   "zebra": True
 }%}
-
-{%- macro service_dependencies(service_name=False) -%}
-- watch_in:
-{%-   if service_name and not map.one_service_to_start_them_all %}
-  - service: frr_{{ service_name }}_service
-{%-   else %}
-  - service: frr_service
-{%-   endif %}
-{%-   if map.use_integrated_mode %}
-  - cmd: frr_reload
-{%-   endif %}
-{%- endmacro %}
 
 {%- set services = [] %}{# used below in 'frr_daemons' #}
 {%- for protocol, config in salt['pillar.get']('frr:services', services_defaults, True).items() %}

--- a/frr/flags.sls
+++ b/frr/flags.sls
@@ -1,0 +1,50 @@
+{%- from "frr/map.jinja" import map with context %}
+{%- from "frr/macros.jinja" import service_dependencies %}
+
+{%- macro flag_args(flags) %}
+{%-   for flag, value in flags.items() %}
+--{{ flag }} {{ value }}
+{%-   endfor %}
+{%- endmacro %}
+
+{%- set frr = salt['pillar.get']('frr', {}) %}
+{%- set common_flags = frr.get('common_flags', {}) %}
+
+{%- set alltheflags = {} %}
+{%- for protocol, cfg in frr.get('services', {}).items() %}
+{%-   if protocol == "zebra" %}
+{%-     set service = protocol %}
+{%-   else %}
+{%-     set service = "{}d".format(protocol) %}
+{%-   endif %}
+{%-   set merged_flags = {} %}
+{%-   do merged_flags.update(common_flags) %}
+{%-   do merged_flags.update(cfg.get('flags', {})) %}
+{%-   if merged_flags | length > 0 %}
+{%-     do alltheflags.update({service: merged_flags}) %}
+{%-   endif %}
+{%- endfor %}
+
+{%- if map.manage_sysrc %}
+
+{%-   for service, flags in alltheflags.items() %}
+frr_flags_{{ service }}:
+  sysrc.managed:
+    - name: {{ service }}_flags
+    - value: "{{ flag_args(flags) }}"
+    {{ service_dependencies(service) |indent(4) }}
+{%-   endfor %}
+
+{%- elif grains['os_family'] == 'Debian' %}
+
+{%-   for service, flags in alltheflags.items() %}
+frr_flags_{{ service }}:
+  file.replace:
+    - name: {{ map.default_file }}
+    - pattern: '^{{ service|upper }}_OPTIONS=.*$'
+    - repl: '{{ service|upper }}_OPTIONS="{{ flag_args(flags) }}"'
+    - append_if_not_found: True
+    {{ service_dependencies(service) |indent(4) }}
+{%-   endfor %}
+
+{%- endif %}

--- a/frr/init.sls
+++ b/frr/init.sls
@@ -1,3 +1,4 @@
 include:
   - .install
   - .config
+  - .flags

--- a/frr/macros.jinja
+++ b/frr/macros.jinja
@@ -1,0 +1,13 @@
+{%- from "frr/map.jinja" import map with context %}
+
+{%- macro service_dependencies(service_name=False) -%}
+- watch_in:
+{%-   if service_name and not map.one_service_to_start_them_all %}
+  - service: frr_{{ service_name }}_service
+{%-   else %}
+  - service: frr_service
+{%-   endif %}
+{%-   if map.use_integrated_mode %}
+  - cmd: frr_reload
+{%-   endif %}
+{%- endmacro %}

--- a/frr/osfamilymap.yaml
+++ b/frr/osfamilymap.yaml
@@ -1,3 +1,5 @@
+Debian:
+  default_file: /etc/default/frr
 FreeBSD:
   package: frr6
   conf_dir: /usr/local/etc/frr

--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,10 @@ frr:
     log syslog: debugging
     password: SuperSecurePassword
 
+  # set this for all enabled services
+  common_flags:
+    vty_addr: '127.0.0.1'
+
   # Services not listed here won't be touched.
   services:
     # Babel example
@@ -37,6 +41,8 @@ frr:
     # OSPF example
     # with two tap devices (OpenVPN) and redistribution of loopback addresses
     ospf:
+      flags:
+        moduledir: '/opt/my/ospf/modules'
       config:
         ip prefix-list OSNET seq 10: permit 192.168.255.0/24 le 32
         route-map OSMAP permit 5:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

None.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Allow this formula to alter service flags. In example `ospfd_flags="--vty_addr 127.0.0.1"` in FreeBSD.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

See `pillar.example`, search for "flags".

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
% salt --state-output=changes --state-verbose=False minion state.apply frr test=True
minion:
----------
          ID: frr_flags_zebra
    Function: sysrc.managed
        Name: zebra_flags
      Result: None
     Comment: The value of "zebra_flags" will be changed!
     Started: 23:03:06.381494
    Duration: 446.121 ms
     Changes:   
              ----------
              new:
                  zebra_flags =  --vty_addr 127.0.0.1 --test asdf will be set.
              old:
                  ----------
                  /etc/rc.conf:
                      ----------
                      zebra_flags:
                           --vty_addr 127.0.0.1
----------
          ID: frr_flags_ospfd
    Function: sysrc.managed
        Name: ospfd_flags
      Result: None
     Comment: The value of "ospfd_flags" will be changed!
     Started: 23:03:06.827886
    Duration: 451.073 ms
     Changes:   
              ----------
              new:
                  ospfd_flags =  --vty_addr 127.0.0.1 --test asdf will be set.
              old:
                  ----------
                  /etc/rc.conf:
                      ----------
                      ospfd_flags:
                           --vty_addr 127.0.0.1
----------
          ID: frr_service
    Function: service.running
        Name: frr
      Result: None
     Comment: Service is set to be restarted
     Started: 23:03:08.948288
    Duration: 424.904 ms
     Changes:   

Summary for main.srv.tty1.eu
-------------
Succeeded: 16 (unchanged=3, changed=2)
Failed:     0
-------------
Total states run:     16
Total run time:    4.329 s
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


