### PR TITLE
CentOS FRR repo support

### DIFF
--- a/frr/defaults.yaml
+++ b/frr/defaults.yaml
@@ -6,6 +6,7 @@ frr:
   package_url: False
   # Hash to proove the integrity of the package file. (Only used with package_url.)
   package_hash: False
+  custom_repos: False
   service: frr
   conf_dir: /etc/frr
   log_dir: /var/log/frr

--- a/frr/install.sls
+++ b/frr/install.sls
@@ -6,6 +6,24 @@
 {%-   set use_repo = True %}
 {%- endif %}
 
+{%- if map.custom_repos and use_repo %}
+{%-   set custom_repos = True %}
+{%- else %}
+{%-   set custom_repos = False %}
+{%- endif %}
+
+{%- if custom_repos %}
+{%-   for repo in map.custom_repos %}
+frr_custom_repo_{{ repo.name }}:
+  pkgrepo.managed:
+{%-     for key, value in repo.items() %}
+    - {{ key }}: {{ value }}
+{%-     endfor %}
+    - require_in:
+      - pkg: frr_package
+{%-   endfor %}
+{%- endif %}
+
 {%- if not use_repo %}
 # Cache the file in order to verify its integrity:
 frr_package_cached:

--- a/pillar.example
+++ b/pillar.example
@@ -28,7 +28,7 @@ frr:
     #    gpgcheck: 1
     #    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-FRR
     #  - name: frr-extras
-    #    humanname: FRRouting Packages for Enterprise Linux 8 - $basearch
+    #    humanname: FRRouting Dependencies for Enterprise Linux 8 - $basearch
     #    baseurl: https://rpm.frrouting.org/repo/el8/extras
     #    enabled: 1
     #    gpgcheck: 1

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,21 @@ frr:
     # Hash to proove the integrity of the package file. (Only used with package_url.)
     package_hash: False
     #package_hash: sha256=f20cee43e94d136383d27531b848248e8f605e68b20fd257dd17d17228402bf7
+    # Configure custom repos for CentOS.  frr and frr-extras required.
+    # Replace change el8 in the URLs to match your CentOS version.
+    #custom_repos:
+    #  - name: frr
+    #    humanname: FRRouting Packages for Enterprise Linux 8 - $basearch
+    #    baseurl: https://rpm.frrouting.org/repo/el8/frr
+    #    enabled: 1
+    #    gpgcheck: 1
+    #    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-FRR
+    #  - name: frr-extras
+    #    humanname: FRRouting Packages for Enterprise Linux 8 - $basearch
+    #    baseurl: https://rpm.frrouting.org/repo/el8/extras
+    #    enabled: 1
+    #    gpgcheck: 1
+    #    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-FRR
 
   # Configuration common to all services
   common_config:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

None.

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
Allow this formula to manage the FRR package repos for CentOS.  CentOS 7 and 8 only have frr-7.0 in their default repos which is several minor releases behind and lacking features.

Uses pkgrepo.managed to achieve this.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->
```
    custom_repos:
      - name: frr
        humanname: FRRouting Packages for Enterprise Linux 8 - $basearch
        baseurl: https://rpm.frrouting.org/repo/el8/frr
        enabled: 1
        gpgcheck: 1
        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-FRR
      - name: frr-extras
        humanname: FRRouting Dependencies for Enterprise Linux 8 - $basearch
        baseurl: https://rpm.frrouting.org/repo/el8/extras
        enabled: 1
        gpgcheck: 1
        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-FRR
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

If FRR is already installed, repos will be installed and FRR won't be upgraded until a second run with `package_auto_upgrade: True` set in the pillar:

```
[root@salt frr]# salt --state-output=changes --state-verbose=False frr state.apply frr package_auto_upgrade=True test=True
frr:
----------
          ID: frr_custom_repo_frr
    Function: pkgrepo.managed
        Name: frr
      Result: None
     Comment: Package repo 'frr' would be configured. This may cause pkg states to behave differently than stated if this action is repeated without test=True, due to the differences in the configured repositories.
     Started: 17:02:10.788123
    Duration: 2941.39 ms
     Changes:
              ----------
              repo:
                  frr
----------
          ID: frr_custom_repo_frr-extras
    Function: pkgrepo.managed
        Name: frr-extras
      Result: None
     Comment: Package repo 'frr-extras' would be configured. This may cause pkg states to behave differently than stated if this action is repeated without test=True, due to the differences in the configured repositories.
     Started: 17:02:13.729604
    Duration: 13.584 ms
     Changes:
              ----------
              repo:
                  frr-extras

Summary for frr
-------------
Succeeded: 16 (unchanged=2, changed=2)
Failed:     0
-------------
Total states run:     16
Total run time:    6.842 s

```
Second run with `package_auto_upgrade: True` set in the pillar installs the newer package + dependencies from the FRR repos:

```
[root@salt frr]# salt --state-output=changes --state-verbose=False frr state.apply frr test=True
frr:
----------
          ID: frr_package
    Function: pkg.latest
        Name: frr
      Result: None
     Comment: The following packages would be installed/upgraded: frr
     Started: 17:03:38.913382
    Duration: 7346.29 ms
     Changes:

Summary for frr
-------------
Succeeded: 16 (unchanged=1)
Failed:     0
-------------
Total states run:     16
Total run time:   10.417 s
```

If FRR is not already installed, the repos will be installed before the newer FRR package:

```
[root@salt frr]# salt --state-output=changes --state-verbose=False frr state.apply frr
frr:
----------
          ID: frr_custom_repo_frr
    Function: pkgrepo.managed
        Name: frr
      Result: True
     Comment: Configured package repo 'frr'
     Started: 17:16:56.423861
    Duration: 3007.289 ms
     Changes:
              ----------
              repo:
                  frr
----------
          ID: frr_custom_repo_frr-extras
    Function: pkgrepo.managed
        Name: frr-extras
      Result: True
     Comment: Configured package repo 'frr-extras'
     Started: 17:16:59.431244
    Duration: 20.447 ms
     Changes:
              ----------
              repo:
                  frr-extras
----------
          ID: frr_package
    Function: pkg.latest
        Name: frr
      Result: True
     Comment: The following packages were successfully installed/upgraded: frr
     Started: 17:16:59.463507
    Duration: 11647.547 ms
     Changes:
              ----------
              frr:
                  ----------
                  new:
                      7.3-01.el8
                  old:
              libyang:
                  ----------
                  new:
                      1.0.109-0
                  old:
----------
          ID: frr_confdir
    Function: file.directory
        Name: /etc/frr
      Result: True
     Comment: Directory /etc/frr updated
     Started: 17:17:11.125533
    Duration: 1.625 ms
     Changes:
              ----------
              /etc/frr:
                  ----------
                  mode:
                      0750
                  user:
                      root
              mode:
                  0750
              user:
                  root
----------
          ID: frr_rundir
    Function: file.directory
        Name: /var/run/frr
      Result: True
     Comment: Directory /var/run/frr updated
     Started: 17:17:11.127401
    Duration: 0.779 ms
     Changes:
              ----------
              /var/run/frr:
                  ----------
                  mode:
                      0750
              mode:
                  0750
----------
          ID: frr_service_zebra_activation
    Function: file.replace
        Name: /etc/frr/daemons
      Result: True
     Comment: Changes were made
     Started: 17:17:11.204135
    Duration: 3.297 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -78,3 +78,4 @@
                   # or you can use "all_wrap" for all daemons, e.g. to use perf record:
                   #   all_wrap="/usr/bin/perf record --call-graph -"
                   # the normal daemon command is added to this at the end.
                  +zebra=yes
----------
          ID: frr_service_config_zebra
    Function: file.absent
        Name: /etc/frr/zebra.conf
      Result: True
     Comment: Removed file /etc/frr/zebra.conf
     Started: 17:17:11.207534
    Duration: 0.264 ms
     Changes:
              ----------
              removed:
                  /etc/frr/zebra.conf
----------
          ID: frr_service_ospfd_activation
    Function: file.replace
        Name: /etc/frr/daemons
      Result: True
     Comment: Changes were made
     Started: 17:17:11.208901
    Duration: 1.583 ms
     Changes:
              ----------
              diff:
                  ---
                  +++
                  @@ -15,7 +15,7 @@
                   # The watchfrr and zebra daemons are always started.
                   #
                   bgpd=no
                  -ospfd=no
                  +ospfd=yes
                   ospf6d=no
                   ripd=no
                   ripngd=no
----------
          ID: frr_service_config_ospfd
    Function: file.absent
        Name: /etc/frr/ospfd.conf
      Result: True
     Comment: Removed file /etc/frr/ospfd.conf
     Started: 17:17:11.210560
    Duration: 0.254 ms
     Changes:
              ----------
              removed:
                  /etc/frr/ospfd.conf
----------
          ID: frr_service
    Function: service.running
        Name: frr
      Result: True
     Comment: Service frr has been enabled, and is running
     Started: 17:17:11.217600
    Duration: 419.07 ms
     Changes:
              ----------
              frr:
                  True
----------
          ID: frr_reload
    Function: cmd.run
        Name: vtysh -b
      Result: True
     Comment: Command "vtysh -b" run
     Started: 17:17:11.637055
    Duration: 52.225 ms
     Changes:
              ----------
              pid:
                  31820
              retcode:
                  0
              stderr:
              stdout:

Summary for frr
-------------
Succeeded: 16 (changed=11)
Failed:     0
-------------
Total states run:     16
Total run time:   15.233 s
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


